### PR TITLE
Bootstrap no longer requires prepl when running from sbcl

### DIFF
--- a/bin/radiance-bootstrap.lisp
+++ b/bin/radiance-bootstrap.lisp
@@ -615,7 +615,7 @@
     (setf *package* (find-package "CL-USER"))
     (dolist (dist (rest dists))
       (f ql-dist install-dist dist :prompt NIL))
-    (f ql quickload '(prepl radiance))
+    (f ql quickload '(#-sbcl prepl radiance))
     (fixup-environment target)
     (f radiance startup)
     (f radiance shutdown)


### PR DESCRIPTION
It was already optional but there was still one place where it required prepl.